### PR TITLE
Change title of block token distribution in page token

### DIFF
--- a/pages/token.vue
+++ b/pages/token.vue
@@ -60,7 +60,7 @@
       <Container>
         <Feature
           :src="require('~/assets/token/token-distribution.svg')"
-          title="Token distribution"
+          title="Token initial distribution"
           action="Check out our roadmap"
           :to="links.roadmap"
         >


### PR DESCRIPTION
I renamed the block "Token distribution" to "Token initial distribution".

Maybe it's more correct as "Initial token distribution"?